### PR TITLE
Update to Vite 2

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,17 +5,14 @@ import toSource from 'tosource'
 const ext = /\.ya?ml$/
 
 const yamlPlugin: Plugin = {
-  transforms: [
-    {
-      test({ path }) {
-        return ext.test(path)
-      },
-      transform({ code }) {
-        const transformedCode = `const data = ${toSource(safeLoad(code))}\n`
-        return transformedCode + 'export default data'
+  name: 'yaml',
+  transform(code, id) {
+    if (ext.test(id)) {
+      return {
+        code: `export default ${toSource(safeLoad(code))}\n`,
       }
     }
-  ]
+  },
 }
 
 module.exports = yamlPlugin


### PR DESCRIPTION
Hi. This makes the plugin compatible with Vite 2 so it will require a major version bump.
You might want to update to the latest `js-yaml` (v4) as well, which only requires using `load` instead of `safeLoad`.

Thanks.