### PR TITLE
add repository link to package.json so NPM can display it

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
     "name": "Clément BERNARD",
     "email": "clemvnt@gmail.com"
   },
+  "repository": {
+    "url": "https://github.com/clemvnt/vite-plugin-yaml",
+    "type": "git"
+  },
   "license": "MIT",
   "keywords": [
     "vite",


### PR DESCRIPTION
Missing link to repo:

<img width="510" alt="Screen Shot 2021-04-01 at 07 25 17" src="https://user-images.githubusercontent.com/30958850/113247533-8736fe80-92bb-11eb-8215-8609bbd99fd1.png">
